### PR TITLE
feat: allowing for config overrides storage

### DIFF
--- a/api/v1beta1/installation_types.go
+++ b/api/v1beta1/installation_types.go
@@ -37,7 +37,9 @@ type InstallationSpec struct {
 	// AirGap indicates if the installation is airgapped.
 	AirGap bool `json:"airGap"`
 	// Config holds the configuration used at installation time.
-	Config *Config `json:"config,omitempty"`
+	Config *ConfigSpec `json:"config,omitempty"`
+	// ConfigOverrides holds the configuration overrides used at installation time.
+	ConfigOverrides *ConfigSpec `json:"overrides,omitempty"`
 }
 
 // InstallationStatus defines the observed state of Installation

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -187,7 +187,12 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = new(Config)
+		*out = new(ConfigSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ConfigOverrides != nil {
+		in, out := &in.ConfigOverrides, &out.ConfigOverrides
+		*out = new(ConfigSpec)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
+++ b/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
@@ -152,96 +152,156 @@ spec:
               config:
                 description: Config holds the configuration used at installation time.
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    type: object
-                  spec:
-                    description: ConfigSpec defines the desired state of Config
+                  controller:
+                    description: NodeRole is the role of a node in the cluster.
                     properties:
-                      controller:
-                        description: NodeRole is the role of a node in the cluster.
-                        properties:
-                          description:
-                            type: string
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          name:
-                            type: string
-                          nodeCount:
-                            description: NodeCount holds a series of rules for a given node role.
-                            properties:
-                              range:
-                                description: NodeRange contains a min and max or only one of them (conflicts with Values).
-                                properties:
-                                  max:
-                                    description: Max is the maximum number of nodes.
-                                    type: integer
-                                  min:
-                                    description: Min is the minimum number of nodes.
-                                    type: integer
-                                type: object
-                              values:
-                                description: Values holds a list of allowed node counts.
-                                items:
-                                  type: integer
-                                type: array
-                            type: object
+                      description:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
                         type: object
-                      custom:
-                        items:
-                          description: NodeRole is the role of a node in the cluster.
-                          properties:
-                            description:
-                              type: string
-                            labels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            name:
-                              type: string
-                            nodeCount:
-                              description: NodeCount holds a series of rules for a given node role.
-                              properties:
-                                range:
-                                  description: NodeRange contains a min and max or only one of them (conflicts with Values).
-                                  properties:
-                                    max:
-                                      description: Max is the maximum number of nodes.
-                                      type: integer
-                                    min:
-                                      description: Min is the minimum number of nodes.
-                                      type: integer
-                                  type: object
-                                values:
-                                  description: Values holds a list of allowed node counts.
-                                  items:
-                                    type: integer
-                                  type: array
-                              type: object
-                          type: object
-                        type: array
-                      unsupportedOverrides:
-                        description: UnsupportedOverrides holds the config overrides used to configure the cluster.
+                      name:
+                        type: string
+                      nodeCount:
+                        description: NodeCount holds a series of rules for a given node role.
                         properties:
-                          k0s:
-                            description: K0s holds the overrides used to configure k0s. These overrides are merged on top of the default k0s configuration. As the data layout inside this configuration is very dynamic we have chosen to use a string here.
-                            type: string
+                          range:
+                            description: NodeRange contains a min and max or only one of them (conflicts with Values).
+                            properties:
+                              max:
+                                description: Max is the maximum number of nodes.
+                                type: integer
+                              min:
+                                description: Min is the minimum number of nodes.
+                                type: integer
+                            type: object
+                          values:
+                            description: Values holds a list of allowed node counts.
+                            items:
+                              type: integer
+                            type: array
                         type: object
                     type: object
-                  status:
-                    description: ConfigStatus defines the observed state of Config
+                  custom:
+                    items:
+                      description: NodeRole is the role of a node in the cluster.
+                      properties:
+                        description:
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        nodeCount:
+                          description: NodeCount holds a series of rules for a given node role.
+                          properties:
+                            range:
+                              description: NodeRange contains a min and max or only one of them (conflicts with Values).
+                              properties:
+                                max:
+                                  description: Max is the maximum number of nodes.
+                                  type: integer
+                                min:
+                                  description: Min is the minimum number of nodes.
+                                  type: integer
+                              type: object
+                            values:
+                              description: Values holds a list of allowed node counts.
+                              items:
+                                type: integer
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  unsupportedOverrides:
+                    description: UnsupportedOverrides holds the config overrides used to configure the cluster.
+                    properties:
+                      k0s:
+                        description: K0s holds the overrides used to configure k0s. These overrides are merged on top of the default k0s configuration. As the data layout inside this configuration is very dynamic we have chosen to use a string here.
+                        type: string
                     type: object
                 type: object
               metricsBaseURL:
                 description: MetricsBaseURL holds the base URL for the metrics server.
                 type: string
+              overrides:
+                description: ConfigOverrides holds the configuration overrides used at installation time.
+                properties:
+                  controller:
+                    description: NodeRole is the role of a node in the cluster.
+                    properties:
+                      description:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      nodeCount:
+                        description: NodeCount holds a series of rules for a given node role.
+                        properties:
+                          range:
+                            description: NodeRange contains a min and max or only one of them (conflicts with Values).
+                            properties:
+                              max:
+                                description: Max is the maximum number of nodes.
+                                type: integer
+                              min:
+                                description: Min is the minimum number of nodes.
+                                type: integer
+                            type: object
+                          values:
+                            description: Values holds a list of allowed node counts.
+                            items:
+                              type: integer
+                            type: array
+                        type: object
+                    type: object
+                  custom:
+                    items:
+                      description: NodeRole is the role of a node in the cluster.
+                      properties:
+                        description:
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        nodeCount:
+                          description: NodeCount holds a series of rules for a given node role.
+                          properties:
+                            range:
+                              description: NodeRange contains a min and max or only one of them (conflicts with Values).
+                              properties:
+                                max:
+                                  description: Max is the maximum number of nodes.
+                                  type: integer
+                                min:
+                                  description: Min is the minimum number of nodes.
+                                  type: integer
+                              type: object
+                            values:
+                              description: Values holds a list of allowed node counts.
+                              items:
+                                type: integer
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  unsupportedOverrides:
+                    description: UnsupportedOverrides holds the config overrides used to configure the cluster.
+                    properties:
+                      k0s:
+                        description: K0s holds the overrides used to configure k0s. These overrides are merged on top of the default k0s configuration. As the data layout inside this configuration is very dynamic we have chosen to use a string here.
+                        type: string
+                    type: object
+                type: object
             required:
             - airGap
             type: object

--- a/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
+++ b/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
@@ -44,111 +44,173 @@ spec:
               config:
                 description: Config holds the configuration used at installation time.
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    type: object
-                  spec:
-                    description: ConfigSpec defines the desired state of Config
+                  controller:
+                    description: NodeRole is the role of a node in the cluster.
                     properties:
-                      controller:
-                        description: NodeRole is the role of a node in the cluster.
-                        properties:
-                          description:
-                            type: string
-                          labels:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          name:
-                            type: string
-                          nodeCount:
-                            description: NodeCount holds a series of rules for a given
-                              node role.
-                            properties:
-                              range:
-                                description: NodeRange contains a min and max or only
-                                  one of them (conflicts with Values).
-                                properties:
-                                  max:
-                                    description: Max is the maximum number of nodes.
-                                    type: integer
-                                  min:
-                                    description: Min is the minimum number of nodes.
-                                    type: integer
-                                type: object
-                              values:
-                                description: Values holds a list of allowed node counts.
-                                items:
-                                  type: integer
-                                type: array
-                            type: object
+                      description:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
                         type: object
-                      custom:
-                        items:
-                          description: NodeRole is the role of a node in the cluster.
-                          properties:
-                            description:
-                              type: string
-                            labels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            name:
-                              type: string
-                            nodeCount:
-                              description: NodeCount holds a series of rules for a
-                                given node role.
-                              properties:
-                                range:
-                                  description: NodeRange contains a min and max or
-                                    only one of them (conflicts with Values).
-                                  properties:
-                                    max:
-                                      description: Max is the maximum number of nodes.
-                                      type: integer
-                                    min:
-                                      description: Min is the minimum number of nodes.
-                                      type: integer
-                                  type: object
-                                values:
-                                  description: Values holds a list of allowed node
-                                    counts.
-                                  items:
-                                    type: integer
-                                  type: array
-                              type: object
-                          type: object
-                        type: array
-                      unsupportedOverrides:
-                        description: UnsupportedOverrides holds the config overrides
-                          used to configure the cluster.
+                      name:
+                        type: string
+                      nodeCount:
+                        description: NodeCount holds a series of rules for a given
+                          node role.
                         properties:
-                          k0s:
-                            description: K0s holds the overrides used to configure
-                              k0s. These overrides are merged on top of the default
-                              k0s configuration. As the data layout inside this configuration
-                              is very dynamic we have chosen to use a string here.
-                            type: string
+                          range:
+                            description: NodeRange contains a min and max or only
+                              one of them (conflicts with Values).
+                            properties:
+                              max:
+                                description: Max is the maximum number of nodes.
+                                type: integer
+                              min:
+                                description: Min is the minimum number of nodes.
+                                type: integer
+                            type: object
+                          values:
+                            description: Values holds a list of allowed node counts.
+                            items:
+                              type: integer
+                            type: array
                         type: object
                     type: object
-                  status:
-                    description: ConfigStatus defines the observed state of Config
+                  custom:
+                    items:
+                      description: NodeRole is the role of a node in the cluster.
+                      properties:
+                        description:
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        nodeCount:
+                          description: NodeCount holds a series of rules for a given
+                            node role.
+                          properties:
+                            range:
+                              description: NodeRange contains a min and max or only
+                                one of them (conflicts with Values).
+                              properties:
+                                max:
+                                  description: Max is the maximum number of nodes.
+                                  type: integer
+                                min:
+                                  description: Min is the minimum number of nodes.
+                                  type: integer
+                              type: object
+                            values:
+                              description: Values holds a list of allowed node counts.
+                              items:
+                                type: integer
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  unsupportedOverrides:
+                    description: UnsupportedOverrides holds the config overrides used
+                      to configure the cluster.
+                    properties:
+                      k0s:
+                        description: K0s holds the overrides used to configure k0s.
+                          These overrides are merged on top of the default k0s configuration.
+                          As the data layout inside this configuration is very dynamic
+                          we have chosen to use a string here.
+                        type: string
                     type: object
                 type: object
               metricsBaseURL:
                 description: MetricsBaseURL holds the base URL for the metrics server.
                 type: string
+              overrides:
+                description: ConfigOverrides holds the configuration overrides used
+                  at installation time.
+                properties:
+                  controller:
+                    description: NodeRole is the role of a node in the cluster.
+                    properties:
+                      description:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      nodeCount:
+                        description: NodeCount holds a series of rules for a given
+                          node role.
+                        properties:
+                          range:
+                            description: NodeRange contains a min and max or only
+                              one of them (conflicts with Values).
+                            properties:
+                              max:
+                                description: Max is the maximum number of nodes.
+                                type: integer
+                              min:
+                                description: Min is the minimum number of nodes.
+                                type: integer
+                            type: object
+                          values:
+                            description: Values holds a list of allowed node counts.
+                            items:
+                              type: integer
+                            type: array
+                        type: object
+                    type: object
+                  custom:
+                    items:
+                      description: NodeRole is the role of a node in the cluster.
+                      properties:
+                        description:
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        nodeCount:
+                          description: NodeCount holds a series of rules for a given
+                            node role.
+                          properties:
+                            range:
+                              description: NodeRange contains a min and max or only
+                                one of them (conflicts with Values).
+                              properties:
+                                max:
+                                  description: Max is the maximum number of nodes.
+                                  type: integer
+                                min:
+                                  description: Min is the minimum number of nodes.
+                                  type: integer
+                              type: object
+                            values:
+                              description: Values holds a list of allowed node counts.
+                              items:
+                                type: integer
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  unsupportedOverrides:
+                    description: UnsupportedOverrides holds the config overrides used
+                      to configure the cluster.
+                    properties:
+                      k0s:
+                        description: K0s holds the overrides used to configure k0s.
+                          These overrides are merged on top of the default k0s configuration.
+                          As the data layout inside this configuration is very dynamic
+                          we have chosen to use a string here.
+                        type: string
+                    type: object
+                type: object
             required:
             - airGap
             type: object


### PR DESCRIPTION
today users can have one configuration provided through the kots application but they can also provide overrides through the command line when installing a cluster (--overrides flag). this commit adds a property to the crd so we can keep track of the overrides used at install time as well as the config embedded through the kots app.

this commit also moves from keeping the whole config obect to holds only its spec (we don't care about config status).