### PR TITLE
feat: release metadata can now point to a different k0s

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -275,9 +275,14 @@ func (r *InstallationReconciler) StartUpgrade(ctx context.Context, in *v1beta1.I
 	if err != nil {
 		return fmt.Errorf("failed to get release bundle: %w", err)
 	}
-	// XXX we might want to store these somewhere else.
 	repo := "https://github.com/k0sproject/k0s"
 	k0surl := fmt.Sprintf("%[1]s/releases/download/%[2]s/k0s-%[2]s-amd64", repo, meta.Versions.Kubernetes)
+	if meta.K0sBinaryURL != "" {
+		// A given release may indicate a different URL from where the upgrade must fetch
+		// the k0s binary. This is useful if we want to replace the original k0s binary in
+		// one of our releases.
+		k0surl = meta.K0sBinaryURL
+	}
 	plan := apv1b2.Plan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "autopilot",

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -27,8 +27,9 @@ type Versions struct {
 // Meta represents the components of a given embedded cluster release. This
 // is read directly from GitHub releases page.
 type Meta struct {
-	Versions Versions
-	K0sSHA   string
+	Versions     Versions
+	K0sSHA       string
+	K0sBinaryURL string
 }
 
 // MetadataFor reads metadata for a given release. Goes to GitHub releases page


### PR DESCRIPTION
in we want to replace the official k0s binary with our own version now we can make the release to point to a different URL. this URL should point to the binary and the binary must be the same that has been embedded into the embedded-cluster version (sha256 must match).

relates to https://github.com/replicatedhq/embedded-cluster/pull/205