### PR TITLE
feat: notify node changes only at the end of reconcile

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -45,8 +45,8 @@ import (
 // interval.
 var requeueAfter = time.Hour
 
-// NodeEventsBatch is a batch of node events, meants to be gathered at a given
-// time and later sent to the metrics server.
+// NodeEventsBatch is a batch of node events, meant to be gathered at a given
+// moment in time and send later on to the metrics server.
 type NodeEventsBatch struct {
 	NodesAdded   []metrics.NodeEvent
 	NodesUpdated []metrics.NodeEvent

--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -431,6 +431,9 @@ func (r *InstallationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile k0s version: %w", err)
 	}
 	if err := r.Status().Update(ctx, in); err != nil {
+		if errors.IsConflict(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to update status: conflict.")
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to update installation status: %w", err)
 	}
 	r.DisableOldInstallations(ctx, items)


### PR DESCRIPTION
in case of conflicts or problems when saving the installation object we may end up reporting the same event more than once. this commit moves the metrics sending logic to a place after the installation object is saved.