### PR TITLE
feat: do not report upgrade during installation

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -160,7 +160,7 @@ func (r *InstallationReconciler) ReportNodesChanges(ctx context.Context, in *v1b
 
 // ReportInstallationChanges reports back to the metrics server if the installation status has changed.
 func (r *InstallationReconciler) ReportInstallationChanges(ctx context.Context, before, after *v1beta1.Installation) {
-	if before.Status.State == after.Status.State {
+	if len(before.Status.State) == 0 || before.Status.State == after.Status.State {
 		return
 	}
 	var err error


### PR DESCRIPTION
when we first create a new installation object its status is empty therefore it is different from the status after the first reconcile.

on this scenarios we don't want to report back to our metric system as an upgrade succeess.