### PR TITLE
fetch metadata.json and k0s files from replicated.app

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -201,7 +201,7 @@ func (r *InstallationReconciler) ReconcileK0sVersion(ctx context.Context, in *v1
 		in.Status.SetState(v1beta1.InstallationStateKubernetesInstalled, "")
 		return nil
 	}
-	meta, err := release.MetadataFor(ctx, in.Spec.Config.Version)
+	meta, err := release.MetadataFor(ctx, in.Spec.Config.Version, in.Spec.MetricsBaseURL)
 	if err != nil {
 		in.Status.SetState(v1beta1.InstallationStateFailed, err.Error())
 		return nil
@@ -315,7 +315,7 @@ func (r *InstallationReconciler) ReconcileHelmCharts(ctx context.Context, in *v1
 		}
 		return nil
 	}
-	meta, err := release.MetadataFor(ctx, in.Spec.Config.Version)
+	meta, err := release.MetadataFor(ctx, in.Spec.Config.Version, in.Spec.MetricsBaseURL)
 	if err != nil {
 		return fmt.Errorf("failed to get release bundle: %w", err)
 	}
@@ -475,12 +475,13 @@ func (r *InstallationReconciler) StartUpgrade(ctx context.Context, in *v1beta1.I
 	if err != nil {
 		return fmt.Errorf("failed to determine upgrade targets: %w", err)
 	}
-	meta, err := release.MetadataFor(ctx, in.Spec.Config.Version)
+	meta, err := release.MetadataFor(ctx, in.Spec.Config.Version, in.Spec.MetricsBaseURL)
 	if err != nil {
 		return fmt.Errorf("failed to get release bundle: %w", err)
 	}
+
 	k0surl := fmt.Sprintf(
-		"https://replicated.app/embedded-cluster-public-files/k0s-binaries/%s", meta.Versions.Kubernetes,
+		"%s/embedded-cluster-public-files/k0s-binaries/%s", in.Spec.MetricsBaseURL, meta.Versions.Kubernetes,
 	)
 	plan := apv1b2.Plan{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -480,14 +480,8 @@ func (r *InstallationReconciler) StartUpgrade(ctx context.Context, in *v1beta1.I
 		return fmt.Errorf("failed to get release bundle: %w", err)
 	}
 	k0surl := fmt.Sprintf(
-		"https://get.k0sproject.io/%[1]s/k0s-%[1]s-amd64", meta.Versions.Kubernetes,
+		"https://replicated.app/embedded-cluster-public-files/k0s-binaries/%s", meta.Versions.Kubernetes,
 	)
-	if meta.K0sBinaryURL != "" {
-		// A given release may indicate a different URL from where the upgrade must fetch
-		// the k0s binary. This is useful if we want to replace the original k0s binary in
-		// one of our releases.
-		k0surl = meta.K0sBinaryURL
-	}
 	plan := apv1b2.Plan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "autopilot",

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	ghurl = "https://github.com/replicatedhq/embedded-cluster/releases/download/v%s/metadata.json"
-	cache = map[string]*Meta{}
-	mutex = sync.Mutex{}
+	metaURL = "https://replicated.app/embedded-cluster-public-files/metadata/v%s.json"
+	cache   = map[string]*Meta{}
+	mutex   = sync.Mutex{}
 )
 
 // Versions holds a list of add-on versions.
@@ -32,15 +32,13 @@ type Versions struct {
 // Meta represents the components of a given embedded cluster release. This
 // is read directly from GitHub releases page.
 type Meta struct {
-	Versions     Versions
-	K0sSHA       string
-	K0sBinaryURL string
-	Configs      *k0sv1beta1.HelmExtensions
-	Protected    map[string][]string
+	Versions  Versions
+	K0sSHA    string
+	Configs   *k0sv1beta1.HelmExtensions
+	Protected map[string][]string
 }
 
-// MetadataFor reads metadata for a given release. Goes to GitHub releases page
-// and reads metadata.json file.
+// MetadataFor reads metadata for a given release. Goes to replicated.app and reads release metadata file
 func MetadataFor(ctx context.Context, version string) (*Meta, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
@@ -48,7 +46,7 @@ func MetadataFor(ctx context.Context, version string) (*Meta, error) {
 	if meta, ok := cache[version]; ok {
 		return meta, nil
 	}
-	url := fmt.Sprintf(ghurl, version)
+	url := fmt.Sprintf(metaURL, version)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	metaURL = "https://replicated.app/embedded-cluster-public-files/metadata/v%s.json"
+	metaURL = "%s/embedded-cluster-public-files/metadata/v%s.json"
 	cache   = map[string]*Meta{}
 	mutex   = sync.Mutex{}
 )
@@ -39,14 +39,14 @@ type Meta struct {
 }
 
 // MetadataFor reads metadata for a given release. Goes to replicated.app and reads release metadata file
-func MetadataFor(ctx context.Context, version string) (*Meta, error) {
+func MetadataFor(ctx context.Context, version string, upstream string) (*Meta, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 	version = strings.TrimPrefix(version, "v")
 	if meta, ok := cache[version]; ok {
 		return meta, nil
 	}
-	url := fmt.Sprintf(metaURL, version)
+	url := fmt.Sprintf(metaURL, version, upstream)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)


### PR DESCRIPTION
`replicated.app/embedded-cluster-public-files` provides metadata and k0s binaries on a replicated-owned IP, which we should use instead of github IPs.

The k0s binary URL parameter is now redundant as the k0s binary can be downloaded from `replicated.app` directly - even if it is a patched build. An example [on staging](https://staging.replicated.app/embedded-cluster-public-files/k0s-binaries/v1.28.4%2Bk0s.0-ec.0) works now.