### PR TITLE
bug: installation object never gets set to Installed due to false positive chart drift check

### DIFF
--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+
 	"github.com/k0sproject/dig"
 	k0shelm "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
@@ -86,10 +87,7 @@ func mergeHelmConfigs(meta *release.Meta, in *v1beta1.Installation) *k0sv1beta1.
 func detectChartDrift(combinedConfigs *k0sv1beta1.HelmExtensions, installedCharts k0shelm.ChartList) ([]string, bool) {
 	targetCharts := combinedConfigs.Charts
 	chartErrors := []string{}
-	chartDrift := false
-	if len(installedCharts.Items) != len(targetCharts) { // if the desired numbers of charts are different, there is drift
-		chartDrift = true
-	}
+	chartDrift := len(installedCharts.Items) != len(targetCharts)
 	// grab the installed charts
 	for _, chart := range installedCharts.Items {
 		// extract any errors from installed charts

--- a/controllers/helm.go
+++ b/controllers/helm.go
@@ -97,7 +97,7 @@ func detectChartDrift(combinedConfigs *k0sv1beta1.HelmExtensions, installedChart
 		// check for version drift between installed charts and charts in the installer metadata
 		chartSeen := false
 		for _, targetChart := range targetCharts {
-			if targetChart.Name != chart.Spec.ChartName {
+			if targetChart.Name != chart.Spec.ReleaseName {
 				continue
 			}
 			chartSeen = true

--- a/controllers/helm_test.go
+++ b/controllers/helm_test.go
@@ -254,7 +254,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "1.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test",
+								ReleaseName: "test",
 							},
 						},
 						{
@@ -262,7 +262,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "2.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test2",
+								ReleaseName: "test2",
 							},
 						},
 					},
@@ -293,7 +293,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "1.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test",
+								ReleaseName: "test",
 							},
 						},
 					},
@@ -320,7 +320,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "1.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test",
+								ReleaseName: "test",
 							},
 						},
 						{
@@ -328,7 +328,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "2.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test2",
+								ReleaseName: "test2",
 							},
 						},
 					},
@@ -355,7 +355,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "1.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test",
+								ReleaseName: "test",
 							},
 						},
 					},
@@ -386,8 +386,8 @@ func Test_detectChartDrift(t *testing.T) {
 								Error: "test chart error",
 							},
 							Spec: k0shelm.ChartSpec{
-								Version:   "1.0.0",
-								ChartName: "test",
+								Version:     "1.0.0",
+								ReleaseName: "test",
 							},
 						},
 						{
@@ -395,8 +395,8 @@ func Test_detectChartDrift(t *testing.T) {
 								Error: "test chart two error",
 							},
 							Spec: k0shelm.ChartSpec{
-								Version:   "2.0.0",
-								ChartName: "test2",
+								Version:     "2.0.0",
+								ReleaseName: "test2",
 							},
 						},
 					},
@@ -428,7 +428,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "1.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test",
+								ReleaseName: "test",
 							},
 						},
 						{
@@ -437,7 +437,7 @@ func Test_detectChartDrift(t *testing.T) {
 								Version: "2.0.0",
 							},
 							Spec: k0shelm.ChartSpec{
-								ChartName: "test2",
+								ReleaseName: "test2",
 							},
 						},
 					},

--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -292,7 +292,6 @@ func (r *InstallationReconciler) ReconcileHelmCharts(ctx context.Context, in *v1
 		return fmt.Errorf("failed to list installed charts: %w", err)
 	}
 	chartErrors, chartDrift := detectChartDrift(combinedConfigs, installedCharts)
-	fmt.Printf("------- chart drift: %t --------\n", chartDrift)
 
 	// If any chart has errors, update installer state and return
 	if len(chartErrors) > 0 {

--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"testing"
+
 	k0shelmv1beta1 "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
 	"github.com/replicatedhq/embedded-cluster-operator/api/v1beta1"
@@ -12,7 +14,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func TestInstallationReconciler_ReconcileHelmCharts(t *testing.T) {
@@ -104,14 +105,14 @@ func TestInstallationReconciler_ReconcileHelmCharts(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "metachart",
 						},
-						Spec:   k0shelmv1beta1.ChartSpec{ChartName: "metachart"},
+						Spec:   k0shelmv1beta1.ChartSpec{ReleaseName: "metachart"},
 						Status: k0shelmv1beta1.ChartStatus{Version: "1"},
 					},
 					&k0shelmv1beta1.Chart{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "extchart",
 						},
-						Spec:   k0shelmv1beta1.ChartSpec{ChartName: "extchart"},
+						Spec:   k0shelmv1beta1.ChartSpec{ReleaseName: "extchart"},
 						Status: k0shelmv1beta1.ChartStatus{Version: "2"},
 					},
 				},
@@ -157,14 +158,14 @@ func TestInstallationReconciler_ReconcileHelmCharts(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "metachart",
 						},
-						Spec:   k0shelmv1beta1.ChartSpec{ChartName: "metachart"},
+						Spec:   k0shelmv1beta1.ChartSpec{ReleaseName: "metachart"},
 						Status: k0shelmv1beta1.ChartStatus{Version: "1", Error: "metaerror"},
 					},
 					&k0shelmv1beta1.Chart{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "extchart",
 						},
-						Spec:   k0shelmv1beta1.ChartSpec{ChartName: "extchart"},
+						Spec:   k0shelmv1beta1.ChartSpec{ReleaseName: "extchart"},
 						Status: k0shelmv1beta1.ChartStatus{Version: "2", Error: "exterror"},
 					},
 				},


### PR DESCRIPTION
- we always want to surface errors from chart objects
- checking `ChartName` gives us `oci://some/uri` or `repo/releasename` which caused charts to never be "seen"