### PR TITLE
feat: use embedded cluster operator config for version check

### DIFF
--- a/api/v1beta1/installation_types.go
+++ b/api/v1beta1/installation_types.go
@@ -24,6 +24,7 @@ import (
 const (
 	InstallationStateWaiting                string = "Waiting"
 	InstallationStateEnqueued               string = "Enqueued"
+	InstallationStatePreparing              string = "Preparing"
 	InstallationStateInstalling             string = "Installing"
 	InstallationStateInstalled              string = "Installed"
 	InstallationStateKubernetesInstalled    string = "KubernetesInstalled"

--- a/charts/embedded-cluster-operator/templates/embedded-cluster-operator-clusterrole.yaml
+++ b/charts/embedded-cluster-operator/templates/embedded-cluster-operator-clusterrole.yaml
@@ -10,6 +10,7 @@ rules:
   - ""
   resources:
   - nodes
+  - configmaps
   verbs:
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get


### PR DESCRIPTION
instead of fetching the running k8s version we now assess the current version by reading the embedded cluster operator config.