### PR TITLE
feat: take the embedded version cluster into account

### DIFF
--- a/charts/embedded-cluster-operator/templates/embedded-cluster-operator-deployment.yaml
+++ b/charts/embedded-cluster-operator/templates/embedded-cluster-operator-deployment.yaml
@@ -52,6 +52,12 @@ spec:
         command:
         - /manager
         image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
+        env:
+        - name: EMBEDDEDCLUSTER_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: embedded-cluster-config
+              key: embedded-cluster-version
         name: manager
 {{- if .Values.livenessProbe }}
         livenessProbe:


### PR DESCRIPTION
when deciding to start or not an upgrade we should take into account what is the current embedded cluster we are running on. without this fix we end up starting a cluster upgrade when it is not necessary.

we were using the kubernetes version (as in `kubectl version`) to determine if an upgrade was necessary or not. it turns out that when installed with k0s version v1.29.1+k0s.1 the kubernetes version reported is v1.29.1+k0s (notice the missing .1 at the end). because of this the running verion was never equal to the desired version (v1.29.1+k0s.1 != v1.29.1+k0s).

now we take into account the actual embedded cluster version. we do so through an environment variable. this environment variable will change only when the new operator deployment takes place (add-on upgrade) and at that stage the kubernetes has already been upgraded.