### PR TITLE
feat: add a default cluster support bundle

### DIFF
--- a/charts/embedded-cluster-operator/templates/embedded-cluster-operator-secret-support-bundle.yaml
+++ b/charts/embedded-cluster-operator/templates/embedded-cluster-operator-secret-support-bundle.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: embedded-cluster-cluster-support-bundle
+  labels:
+    troubleshoot.io/kind: support-bundle
+type: Opaque
+data:
+  support-bundle-spec: {{ .Files.Get "troubleshoot/cluster-support-bundle.yaml" | b64enc | quote }}

--- a/charts/embedded-cluster-operator/templates/embedded-cluster-operator-secret-support-bundle.yaml
+++ b/charts/embedded-cluster-operator/templates/embedded-cluster-operator-secret-support-bundle.yaml
@@ -7,3 +7,14 @@ metadata:
 type: Opaque
 data:
   support-bundle-spec: {{ .Files.Get "troubleshoot/cluster-support-bundle.yaml" | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: embedded-cluster-host-support-bundle
+  labels:
+    troubleshoot.io/kind: support-bundle
+type: Opaque
+data:
+  support-bundle-spec: {{ .Files.Get "troubleshoot/host-support-bundle.yaml" | b64enc | quote }}
+

--- a/charts/embedded-cluster-operator/templates/embedded-cluster-operator-support-bundle.yaml
+++ b/charts/embedded-cluster-operator/templates/embedded-cluster-operator-support-bundle.yaml
@@ -1,20 +1,18 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: embedded-cluster-cluster-support-bundle
   labels:
     troubleshoot.io/kind: support-bundle
-type: Opaque
 data:
-  support-bundle-spec: {{ .Files.Get "troubleshoot/cluster-support-bundle.yaml" | b64enc | quote }}
+  support-bundle-spec: {{ .Files.Get "troubleshoot/cluster-support-bundle.yaml" | quote }}
 ---
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: embedded-cluster-host-support-bundle
   labels:
     troubleshoot.io/kind: support-bundle
-type: Opaque
 data:
-  support-bundle-spec: {{ .Files.Get "troubleshoot/host-support-bundle.yaml" | b64enc | quote }}
+  support-bundle-spec: {{ .Files.Get "troubleshoot/host-support-bundle.yaml" | quote }}
 

--- a/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+++ b/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
@@ -1,0 +1,70 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: embedded-cluster-cluster-support-bundle
+  labels:
+    troubleshoot.io/kind: support-bundle
+spec:
+  uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster-operator/main/charts/embedded-cluster-operator/troubleshoot/cluster-support-bundle.yaml
+  collectors:
+  - logs:
+      name: podlogs/embedded-cluster-operator
+      namespace: embedded-cluster
+      selector:
+      - app.kubernetes.io/name=embedded-cluster-operator
+      limits:
+        maxAge: 720h
+  - logs:
+      name: podlogs/calico-kube-controllers
+      namespace: kube-system
+      selector:
+      - k8s-app=calico-kube-controllers
+      limits:
+        maxAge: 720h
+  - logs:
+      name: podlogs/calico-node
+      namespace: kube-system
+      selector:
+      - k8s-app=calico-node
+      limits:
+        maxAge: 720h
+  - logs:
+      name: podlogs/coredns
+      namespace: kube-system
+      selector:
+      - k8s-app=kube-dns
+      limits:
+        maxAge: 720h
+  - logs:
+      name: podlogs/kube-proxy
+      namespace: kube-system
+      selector:
+      - k8s-app=kube-proxy
+      limits:
+        maxAge: 720h
+  - logs:
+      name: podlogs/metrics-server
+      namespace: kube-system
+      selector:
+      - k8s-app=metrics-server
+      limits:
+        maxAge: 720h
+  - logs:
+      name: podlogs/openebs
+      namespace: openebs
+      selector:
+      - app=openebs
+      limits:
+        maxAge: 720h
+  analyzers:
+  - textAnalyze:
+      checkName: Cluster installation status
+      fileName: cluster-resources/custom-resources/installations.embeddedcluster.replicated.com.yaml
+      regex: 'state: Installed'
+      outcomes:
+      - fail:
+          when: "false"
+          message: Cluster installation in 'Installed' state not found
+      - pass:
+          when: "true"
+          message: Cluster installation in 'Installed' state found

--- a/charts/embedded-cluster-operator/troubleshoot/host-support-bundle.yaml
+++ b/charts/embedded-cluster-operator/troubleshoot/host-support-bundle.yaml
@@ -1,0 +1,79 @@
+apiVersion: troubleshoot.sh/v1beta2
+kind: SupportBundle
+metadata:
+  name: embedded-cluster-supportbundle
+spec:
+  uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster-operator/main/charts/embedded-cluster-operator/troubleshoot/host-support-bundle.yaml
+  hostCollectors:
+  - cpu: {}
+  - hostOS: {}
+  - memory: {}
+  - blockDevices: {}
+  - diskUsage:
+      collectorName: root-disk-usage
+      path: /
+  - diskUsage:
+      collectorName: openebs-disk-usage
+      path: /var/openebs/local
+  - run:
+      collectorName: k0s-status
+      command: k0s
+      args: [ "status" ]
+  - run:
+      collectorName: k0s-issue-template
+      command: sh
+      args: [ "-c", "uname -srvmo; cat /etc/os-release || lsb_release -a" ]
+  - run:
+      collectorName: k0s-sysinfo
+      command: k0s
+      args: [ "sysinfo" ]
+  hostAnalyzers:
+  - memory:
+      checkName: Amount of Memory
+      outcomes:
+      - warn:
+          when: "< 2G"
+          message: At least 2G of memory is recommended
+      - pass:
+          message: The system has at least 2G of memory
+  - diskUsage:
+      checkName: Root disk usage
+      collectorName: root-disk-usage
+      outcomes:
+      - fail:
+          when: "total < 40Gi"
+          message: The disk containing directory / has less than 40Gi of total space
+      - warn:
+          when: "used/total > 80%"
+          message: The disk containing directory / is more than 80% full
+      - warn:
+          when: "available < 10Gi"
+          message: The disk containing directory / has less than 10Gi of disk space available
+      - pass:
+          message: The disk containing directory / has sufficient space
+  - diskUsage:
+      checkName: OpenEBS disk usage
+      collectorName: openebs-disk-usage
+      outcomes:
+      - fail:
+          when: "total < 40Gi"
+          message: The disk containing OpenEBS volumes has less than 40Gi of space
+      - warn:
+          when: "used/total > 80%"
+          message: The disk containing OpenEBS volumes is more than 80% full
+      - warn:
+          when: "available < 10Gi"
+          message:  The disk containing OpenEBS volumes has less than 10Gi of disk space available
+      - pass:
+          message: The disk containing directory OpenEBS volumes has sufficient space
+  - textAnalyze:
+      checkName: Kubernetes API probing
+      fileName: host-collectors/run-host/k0s-status.txt
+      regex: 'Kube-api probing successful: true'
+      outcomes:
+      - fail:
+          when: "false"
+          message: Kubernetes API probing is reporting a failure
+      - pass:
+          when: "true"
+          message: Kubernetes API probing is reporting success

--- a/charts/embedded-cluster-operator/troubleshoot/host-support-bundle.yaml
+++ b/charts/embedded-cluster-operator/troubleshoot/host-support-bundle.yaml
@@ -1,7 +1,7 @@
 apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
 metadata:
-  name: embedded-cluster-supportbundle
+  name: embedded-cluster-host-support-bundle
 spec:
   uri: https://raw.githubusercontent.com/replicatedhq/embedded-cluster-operator/main/charts/embedded-cluster-operator/troubleshoot/host-support-bundle.yaml
   hostCollectors:
@@ -27,6 +27,9 @@ spec:
       collectorName: k0s-sysinfo
       command: k0s
       args: [ "sysinfo" ]
+  - copy:
+      collectorName: installer-logs
+      path: /var/lib/embedded-cluster/logs/*.log
   hostAnalyzers:
   - memory:
       checkName: Amount of Memory


### PR DESCRIPTION
So far collects logs for all "default" pods, see list below. Kots pods are not collected as its log collection will be placed in the kots-helm repository. Implements only one analyser: checks if an Installation object with "Installed" state exists. The support bundle has its URI property pointing to itself here in the main branch.

Pod logs collected:

- Embedded Cluster Operator
- Calico
- CoreDNS
- Kube proxy
- Metrics server
- OpenEBS