### PR TITLE
make manifests for embeddedClusterMetadata field

### DIFF
--- a/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
+++ b/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
@@ -229,12 +229,15 @@ spec:
                 properties:
                   embeddedClusterBinary:
                     type: string
+                  embeddedClusterMetadata:
+                    type: string
                   helmCharts:
                     type: string
                   images:
                     type: string
                 required:
                 - embeddedClusterBinary
+                - embeddedClusterMetadata
                 - helmCharts
                 - images
                 type: object

--- a/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
+++ b/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
@@ -60,12 +60,15 @@ spec:
                 properties:
                   embeddedClusterBinary:
                     type: string
+                  embeddedClusterMetadata:
+                    type: string
                   helmCharts:
                     type: string
                   images:
                     type: string
                 required:
                 - embeddedClusterBinary
+                - embeddedClusterMetadata
                 - helmCharts
                 - images
                 type: object

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ohler55/ojg v1.21.4
 	github.com/onsi/ginkgo/v2 v2.16.0
 	github.com/onsi/gomega v1.31.1
-	github.com/replicatedhq/embedded-cluster-kinds v1.1.0
+	github.com/replicatedhq/embedded-cluster-kinds v1.1.1
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,10 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/replicatedhq/embedded-cluster-kinds v1.1.0 h1:brGxyi/mG7pEohE4ZNRbeYBVOcDFBaMP/jt9VdcKTWY=
 github.com/replicatedhq/embedded-cluster-kinds v1.1.0/go.mod h1:LheSDOgMngMRAbwAj0sVZUVv2ciKIVR2bYTMeOBGwlg=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.1-0.20240326194610-a6ce4194778a h1:Qr64pwU3fxRpraNTQbKxJqzOK8r7NbkIrf3aGIYuzhA=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.1-0.20240326194610-a6ce4194778a/go.mod h1:LheSDOgMngMRAbwAj0sVZUVv2ciKIVR2bYTMeOBGwlg=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.1 h1:300bVpCBHtZ9acJgEHL3/S4CapvxCRfcSwg/adMNWW8=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.1/go.mod h1:LheSDOgMngMRAbwAj0sVZUVv2ciKIVR2bYTMeOBGwlg=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/101432/trigger-airgap-upgrade-from-kots

runs `make manifests` after updating `github.com/replicatedhq/embedded-cluster-kinds` to `v1.1.1`