### PR TITLE
bug: stop using plan id to index autopilot plans

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	apv1b2 "github.com/k0sproject/k0s/pkg/apis/autopilot/v1beta2"
 	k0shelm "github.com/k0sproject/k0s/pkg/apis/helm/v1beta1"
 	k0sv1beta1 "github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
@@ -50,6 +51,10 @@ import (
 	"github.com/replicatedhq/embedded-cluster-operator/pkg/metrics"
 	"github.com/replicatedhq/embedded-cluster-operator/pkg/release"
 )
+
+// InstallationNameAnnotation is the annotation we keep in the autopilot plan so we can
+// map 1 to 1 one installation and one plan.
+const InstallationNameAnnotation = "embedded-cluster.replicated.com/installation-name"
 
 // requeueAfter is our default interval for requeueing. If nothing has changed with the
 // cluster nodes or the Installation object we will reconcile once every requeueAfter
@@ -549,7 +554,10 @@ func (r *InstallationReconciler) ReconcileK0sVersion(ctx context.Context, in *v1
 
 	// if we have created this plan we just found for the installation we are
 	// reconciling we set the installation state according to the plan state.
-	if plan.Spec.ID == in.Name {
+	// we check both the plan id and an annotation inside the plan. the usage
+	// of the plan id is deprecated in favour of the annotation.
+	annotation := plan.Annotations[InstallationNameAnnotation]
+	if annotation == in.Name || plan.Spec.ID == in.Name {
 		r.SetStateBasedOnPlan(in, plan)
 		return nil
 	}
@@ -838,10 +846,13 @@ func (r *InstallationReconciler) StartUpgrade(ctx context.Context, in *v1beta1.I
 	plan := apv1b2.Plan{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "autopilot",
+			Annotations: map[string]string{
+				InstallationNameAnnotation: in.Name,
+			},
 		},
 		Spec: apv1b2.PlanSpec{
 			Timestamp: "now",
-			ID:        in.Name,
+			ID:        uuid.New().String(),
 			Commands:  commands,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.7
 
 require (
 	github.com/go-logr/logr v1.4.1
+	github.com/google/uuid v1.3.0
 	github.com/gosimple/slug v1.14.0
 	github.com/k0sproject/dig v0.2.0
 	github.com/k0sproject/k0s v1.28.5-0.20231116142149-82f76181191c
@@ -46,7 +47,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect


### PR DESCRIPTION
plan's id is used internally to verify if a given plan has already been executed or not. if we create two different plans with the same id autopilot does not seem to be running the second as it consider it already finished.

we now start to use a random id and use an annotation to keep track of the 1 to 1 mapping between installation and autopilot plan.