### PR TITLE
add eco labels to support bundle configmap

### DIFF
--- a/charts/embedded-cluster-operator/templates/embedded-cluster-operator-support-bundle.yaml
+++ b/charts/embedded-cluster-operator/templates/embedded-cluster-operator-support-bundle.yaml
@@ -4,5 +4,8 @@ metadata:
   name: embedded-cluster-cluster-support-bundle
   labels:
     troubleshoot.sh/kind: support-bundle
+    {{- with (include "embedded-cluster-operator.labels" $ | fromYaml) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   support-bundle-spec: {{ .Files.Get "troubleshoot/cluster-support-bundle.yaml" | quote }}


### PR DESCRIPTION
This PR adds the `embedded-cluster-operator.labels` to the support bundle configmap that is part of the Helm chart templates. These labels are already applied to all other resources, but were not for this configmap.

Example - with the following values:
```
global:
  labels:
    example.com/back-me-up: "true"
```
it renders:
```
# Source: embedded-cluster-operator/templates/embedded-cluster-operator-support-bundle.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: embedded-cluster-cluster-support-bundle
  labels:
    troubleshoot.sh/kind: support-bundle
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: embedded-cluster-operator
    example.com/back-me-up: "true"
    helm.sh/chart: embedded-cluster-operator-0.0.0
data:
...
```