### PR TITLE
bug: fix various issues with the reconcile

### DIFF
--- a/charts/embedded-cluster-operator/templates/embedded-cluster-operator-clusterrole.yaml
+++ b/charts/embedded-cluster-operator/templates/embedded-cluster-operator-clusterrole.yaml
@@ -43,6 +43,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - embeddedcluster.replicated.com
   resources:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ohler55/ojg v1.22.0
 	github.com/onsi/ginkgo/v2 v2.17.2
 	github.com/onsi/gomega v1.33.1
-	github.com/replicatedhq/embedded-cluster-kinds v1.1.10
+	github.com/replicatedhq/embedded-cluster-kinds v1.1.11
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.30.0
 	k8s.io/apimachinery v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/replicatedhq/embedded-cluster-kinds v1.1.10 h1:AguUFkzjb4/hIXKbEhAHzppAmy1ZNMuslzgEIMXGAsk=
-github.com/replicatedhq/embedded-cluster-kinds v1.1.10/go.mod h1:EBLOLIx/5GQsA1KB7Wrv98nfydBRP7V+5PFMRb1AGnU=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.11 h1:M4a8TPINV8jILw85Pk24lcEqrTbSVg2+mdmAi5M6ZZQ=
+github.com/replicatedhq/embedded-cluster-kinds v1.1.11/go.mod h1:EBLOLIx/5GQsA1KB7Wrv98nfydBRP7V+5PFMRb1AGnU=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
- allow the operator to watch secrets.
- sends over a copy of installation when updating its status.
- disable old installations even on failure while reading config.
- bump embedded-cluster-kinds.