### PR TITLE
pull artifacts with and without tls

### DIFF
--- a/pkg/artifacts/artifacts.go
+++ b/pkg/artifacts/artifacts.go
@@ -2,11 +2,14 @@ package artifacts
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/go-logr/logr"
+	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -96,14 +99,32 @@ func Pull(ctx context.Context, log logr.Logger, cli client.Client, from string) 
 	}
 	defer fs.Close()
 
-	// setup the pull options. XXX we are using a registry over http.
-	repo.Client = &auth.Client{Credential: store.Get}
-	repo.PlainHTTP = true
+	transp, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return "", fmt.Errorf("unable to get default transport")
+	}
+
+	transp = transp.Clone()
+	transp.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	repo.Client = &auth.Client{
+		Client:     &http.Client{Transport: transp},
+		Credential: store.Get,
+	}
 
 	tag := imgref.Reference
+	_, tlserr := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions)
+	if tlserr == nil {
+		return tmpdir, nil
+	}
+
+	// if we fail to fetch the artifact using https we gonna try once more using plain
+	// http as some versions of the registry were deployed without tls.
+	repo.PlainHTTP = true
+	log.Info("unable to fetch artifact using tls, retrying with http")
 	if _, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions); err != nil {
 		os.RemoveAll(tmpdir)
-		return "", fmt.Errorf("unable to copy: %w", err)
+		err = multierr.Combine(tlserr, err)
+		return "", fmt.Errorf("unable to fetch artifacts with or without tls: %w", err)
 	}
 	return tmpdir, nil
 }


### PR DESCRIPTION
This PR modifies the operator so that it can pull OCI artifacts with and without TLS. This complements changes in https://github.com/replicatedhq/embedded-cluster/pull/630