### PR TITLE
update crds for isHighAvailability field

### DIFF
--- a/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
+++ b/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
@@ -496,6 +496,9 @@ spec:
                   EndUserK0sConfigOverrides holds the end user k0s config overrides
                   used at installation time.
                 type: string
+              isHighAvailability:
+                description: IsHighAvailability indicates if the installation is high availability.
+                type: boolean
               licenseInfo:
                 description: LicenseInfo holds information about the license used to install the cluster.
                 properties:
@@ -507,6 +510,7 @@ spec:
                 type: string
             required:
             - airGap
+            - isHighAvailability
             type: object
           status:
             description: InstallationStatus defines the observed state of Installation

--- a/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
+++ b/config/crd/bases/embeddedcluster.replicated.com_installations.yaml
@@ -282,6 +282,10 @@ spec:
                   EndUserK0sConfigOverrides holds the end user k0s config overrides
                   used at installation time.
                 type: string
+              isHighAvailability:
+                description: IsHighAvailability indicates if the installation is high
+                  availability.
+                type: boolean
               licenseInfo:
                 description: LicenseInfo holds information about the license used
                   to install the cluster.
@@ -294,6 +298,7 @@ spec:
                 type: string
             required:
             - airGap
+            - isHighAvailability
             type: object
           status:
             description: InstallationStatus defines the observed state of Installation

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ohler55/ojg v1.22.0
 	github.com/onsi/ginkgo/v2 v2.17.3
 	github.com/onsi/gomega v1.33.1
-	github.com/replicatedhq/embedded-cluster-kinds v1.2.4
+	github.com/replicatedhq/embedded-cluster-kinds v1.3.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/multierr v1.11.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/replicatedhq/embedded-cluster-kinds v1.2.4 h1:jt4iriW2Y1YAhQXf1HH7N8tGj7dNup6im25gMQElnTc=
-github.com/replicatedhq/embedded-cluster-kinds v1.2.4/go.mod h1:YognvIhVsE5CevfCU0XLTMUCIAiXhWyYhwbU0EwCnvA=
+github.com/replicatedhq/embedded-cluster-kinds v1.3.0 h1:7KgSK25kcsOmMdcVgGooaeOTO65kZYc9sJTvsbUYK8A=
+github.com/replicatedhq/embedded-cluster-kinds v1.3.0/go.mod h1:YognvIhVsE5CevfCU0XLTMUCIAiXhWyYhwbU0EwCnvA=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
bumps the `github.com/replicatedhq/embedded-cluster-kinds` import to v1.3.0 and re-generates the CRDs for the new `isHighAvailability` field in the Installation spec