### PR TITLE
feat: Store host preflight results in config map for new nodes

### DIFF
--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -913,10 +913,15 @@ func TestInstallationReconciler_constructCreateCMCommand(t *testing.T) {
 	require.Len(t, job.Spec.Template.Spec.Containers, 1)
 	require.Len(t, job.Spec.Template.Spec.Containers[0].Command, 4)
 	kctlCmd := job.Spec.Template.Spec.Containers[0].Command[3]
-	expected := "if [ -f /var/lib/embedded-cluster/support/host-preflight-results.json ]; then /var/lib/embedded-cluster/bin/kubectl create configmap ${EC_NODE_NAME}-host-preflight-results --from-file=results.json=/var/lib/embedded-cluster/support/host-preflight-results.json -n embedded-cluster --dry-run=client -oyaml | /var/lib/embedded-cluster/bin/kubectl label -f - embedded-cluster/host-preflight-result=${EC_NODE_NAME} --local -o yaml | /var/lib/embedded-cluster/bin/kubectl apply -f - && /var/lib/embedded-cluster/bin/kubectl annotate configmap ${EC_NODE_NAME}-host-preflight-results \"update-timestamp=$(date +'%Y-%m-%dT%H:%M:%SZ')\" --overwrite; else echo '/var/lib/embedded-cluster/support/host-preflight-results.json does not exist'; fi"
+	expected := "if [ -f /var/lib/embedded-cluster/support/host-preflight-results.json ]; then /var/lib/embedded-cluster/bin/kubectl create configmap ${HSPF_CM_NAME} --from-file=results.json=/var/lib/embedded-cluster/support/host-preflight-results.json -n embedded-cluster --dry-run=client -oyaml | /var/lib/embedded-cluster/bin/kubectl label -f - embedded-cluster/host-preflight-result=${EC_NODE_NAME} --local -o yaml | /var/lib/embedded-cluster/bin/kubectl apply -f - && /var/lib/embedded-cluster/bin/kubectl annotate configmap ${HSPF_CM_NAME} \"update-timestamp=$(date +'%Y-%m-%dT%H:%M:%SZ')\" --overwrite; else echo '/var/lib/embedded-cluster/support/host-preflight-results.json does not exist'; fi"
 	assert.Equal(t, expected, kctlCmd)
+	require.Len(t, job.Spec.Template.Spec.Containers[0].Env, 2)
 	assert.Equal(t, v1.EnvVar{
 		Name:  "EC_NODE_NAME",
 		Value: "my-node",
 	}, job.Spec.Template.Spec.Containers[0].Env[0])
+	assert.Equal(t, v1.EnvVar{
+		Name:  "HSPF_CM_NAME",
+		Value: "my-node-host-preflight-results",
+	}, job.Spec.Template.Spec.Containers[0].Env[1])
 }

--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -913,7 +913,7 @@ func TestInstallationReconciler_constructCreateCMCommand(t *testing.T) {
 	require.Len(t, job.Spec.Template.Spec.Containers, 1)
 	require.Len(t, job.Spec.Template.Spec.Containers[0].Command, 4)
 	kctlCmd := job.Spec.Template.Spec.Containers[0].Command[3]
-	expected := "export KCTL=/var/lib/embedded-cluster/bin/kubectl\nif [ -f /var/lib/embedded-cluster/support/host-preflight-results.json ]; then ${KCTL} create configmap ${EC_NODE_NAME}-host-preflight-results --from-file=results.json=/var/lib/embedded-cluster/support/host-preflight-results.json -n embedded-cluster --dry-run=client -oyaml | ${KCTL} label -f - embedded-cluster/host-preflight-result=${EC_NODE_NAME} --local -o yaml | ${KCTL} apply -f -; else echo '/var/lib/embedded-cluster/support/host-preflight-results.json does not exist'; fi"
+	expected := "if [ -f /var/lib/embedded-cluster/support/host-preflight-results.json ]; then /var/lib/embedded-cluster/bin/kubectl create configmap ${EC_NODE_NAME}-host-preflight-results --from-file=results.json=/var/lib/embedded-cluster/support/host-preflight-results.json -n embedded-cluster --dry-run=client -oyaml | /var/lib/embedded-cluster/bin/kubectl label -f - embedded-cluster/host-preflight-result=${EC_NODE_NAME} --local -o yaml | /var/lib/embedded-cluster/bin/kubectl apply -f - && /var/lib/embedded-cluster/bin/kubectl annotate configmap ${EC_NODE_NAME}-host-preflight-results \"update-timestamp=$(date +'%Y-%m-%dT%H:%M:%SZ')\" --overwrite; else echo '/var/lib/embedded-cluster/support/host-preflight-results.json does not exist'; fi"
 	assert.Equal(t, expected, kctlCmd)
 	assert.Equal(t, v1.EnvVar{
 		Name:  "EC_NODE_NAME",

--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/replicatedhq/embedded-cluster-kinds/apis/v1beta1"
 	ectypes "github.com/replicatedhq/embedded-cluster-kinds/types"
 	"github.com/replicatedhq/embedded-cluster-operator/pkg/release"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -904,4 +905,10 @@ password: original`,
 			}
 		})
 	}
+}
+
+func TestInstallationReconciler_constructCreateCMCommand(t *testing.T) {
+	cmd := constructCreateCMCommand("my-node")
+	expected := "if [ -f /var/lib/embedded-cluster/support/host-preflight-results.json ]; then /var/lib/embedded-cluster/bin/kubectl create configmap my-node-host-preflight-results --from-file=results.json=/var/lib/embedded-cluster/support/host-preflight-results.json -n embedded-cluster --dry-run=client -oyaml | /var/lib/embedded-cluster/bin/kubectl label -f - embedded-cluster/host-preflight-result=my-node --local -o yaml | /var/lib/embedded-cluster/bin/kubectl apply -f -; else echo '/var/lib/embedded-cluster/support/host-preflight-results.json does not exist'; fi"
+	assert.Equal(t, expected, cmd)
 }

--- a/pkg/util/name.go
+++ b/pkg/util/name.go
@@ -12,5 +12,4 @@ func NameWithLengthLimit(prefix, suffix string) string {
 	// remove characters from the middle of the string to reduce the total length to 63 characters
 	newCandidate := candidate[0:31] + candidate[len(candidate)-32:]
 	return newCandidate
-
 }


### PR DESCRIPTION
When a new node event is received create a new job that fetches host preflight results from the new node and stores the results JSON in configmap named `my-node-host-preflight-results` in a `results.json` key