### PR TITLE
Use ec-install label for installation crd

### DIFF
--- a/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
+++ b/charts/embedded-cluster-operator/charts/crds/templates/resources.yaml
@@ -224,8 +224,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
-    replicated.com/disaster-recovery: infra
-    replicated.com/disaster-recovery-chart: embedded-cluster-operator
+    replicated.com/disaster-recovery: ec-install
   name: installations.embeddedcluster.replicated.com
 spec:
   group: embeddedcluster.replicated.com

--- a/config/crd/patches/labels_in_installations.yaml
+++ b/config/crd/patches/labels_in_installations.yaml
@@ -3,6 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    replicated.com/disaster-recovery: "infra"
-    replicated.com/disaster-recovery-chart: "embedded-cluster-operator"
+    replicated.com/disaster-recovery: "ec-install"
   name: installations.embeddedcluster.replicated.com


### PR DESCRIPTION
The `ec-install` value [is used](https://github.com/replicatedhq/embedded-cluster/blob/bf3f84af3af87eb31106ed2e521e471400d96436/pkg/addons/embeddedclusteroperator/embeddedclusteroperator.go#L205) for the installation CR. The CRD should use the same label so that the CR restores successfully.