### PR TITLE
fix: prevent chart from changing name on upgrade

### DIFF
--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -259,7 +259,7 @@ func patchExtensionsForAirGap(config *v1beta1.Helm) *v1beta1.Helm {
 	config.Repositories = nil
 	for idx, chart := range config.Charts {
 		chartName := fmt.Sprintf("%s-%s.tgz", chart.Name, chart.Version)
-		chartPath := filepath.Join("var", "lib", "embedded-cluster", "charts", chartName)
+		chartPath := filepath.Join("/var/lib/embedded-cluster/charts", chartName)
 		config.Charts[idx].ChartName = chartPath
 	}
 	return config


### PR DESCRIPTION
The name of the chart in the CR on install

```
  chartName: /var/lib/embedded-cluster/charts/docker-registry-2.2.3.tgz
```

The name of the chart in the CR after upgrade

```
  chartName: var/lib/embedded-cluster/charts/docker-registry-2.2.3.tgz
```